### PR TITLE
More accurate level detection

### DIFF
--- a/GoOnTap.Android/Constants.cs
+++ b/GoOnTap.Android/Constants.cs
@@ -59,7 +59,7 @@ public class PokemonInfo
 
         return name;
     }
-    public static double GetLevelAngle(double level, int playerLevel) => (Constants.CPMultipliers[level] - 0.094) * 202.037116 / Constants.CPMultipliers[playerLevel];
+    public static double GetLevelAngle(double level, int playerLevel) => (Constants.CPMultipliers[level] - 0.094) * 180.0 / (Constants.CPMultipliers[Math.Min(playerLevel + 1.5, 40.5)] - 0.094);
 }
 
 public partial class Constants

--- a/GoOnTap.Android/ImageProcessor.cs
+++ b/GoOnTap.Android/ImageProcessor.cs
@@ -354,10 +354,10 @@ namespace GoOnTap
 
             Task<int> pokemonLevel = Task.Run(() =>
             {
-                return Enumerable.Range(1, 179).Reverse().FirstOrDefault(d =>
+                return Enumerable.Range(1, 180).Reverse().FirstOrDefault(d =>
                 {
                     // Get the pixel matching the angle
-                    float r1 = d * (float)Math.PI / 180;
+                    float r1 = ((float)d - 0.5f) * (float)Math.PI / 180;
                     float x1 = arcCenter - (float)Math.Cos(r1) * arcWidth / 2;
                     float y1 = arcY - (float)Math.Sin(r1) * arcWidth / 2;
 
@@ -367,7 +367,7 @@ namespace GoOnTap
                         return false;
 
                     // Get the pixel nearby
-                    float r2 = (d + 2) * (float)Math.PI / 180;
+                    float r2 = ((float)d + 1.5f) * (float)Math.PI / 180;
                     float x2 = arcCenter - (float)Math.Cos(r2) * arcWidth / 2;
                     float y2 = arcY - (float)Math.Sin(r2) * arcWidth / 2;
 
@@ -654,7 +654,7 @@ namespace GoOnTap
             return new ImageData()
             {
                 Name = await pokemonName,
-                LevelAngle = (await pokemonLevel - 1) / 178f * 180,
+                LevelAngle = await pokemonLevel,
                 CP = await pokemonCp,
                 HP = await pokemonHp,
 

--- a/GoOnTap.Android/Interaction/InteractionSession.cs
+++ b/GoOnTap.Android/Interaction/InteractionSession.cs
@@ -524,7 +524,7 @@ namespace GoOnTap.Android
         private double GetPokemonLevel(float levelAngle)
         {
             int playerLevel = GoOnTapApplication.Config.PlayerLevel;
-            double maxLevel = Math.Min(playerLevel + 1.5, 40);
+            double maxLevel = Math.Min(playerLevel + 1.5, 40.5);
             Dictionary<double, double> levels = new Dictionary<double, double>();
 
             for (double level = 1; level <= maxLevel; level += 0.5)


### PR DESCRIPTION
Improved formulas for interpreting the position of the dot on the arc. I now get perfect discrimination between half-levels on a level 31 account (arc going up to level 32.5).

(Note: Previous pull request accidentally got extended with unrelated changes. Please merge this one instead.)